### PR TITLE
feat(client): implement game loop screens and custom symptoms UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,8 @@ import { PlayerProvider } from './context/PlayerContext';
 import { GameProvider } from './context/GameContext';
 import HomeScreen from './screens/HomeScreen';
 import LobbyScreen from './screens/LobbyScreen';
+import GameScreen from './screens/GameScreen';
+import LeaderboardScreen from './screens/LeaderboardScreen';
 import './styles/global.css';
 
 export default function App() {
@@ -13,6 +15,8 @@ export default function App() {
           <Routes>
             <Route path="/" element={<HomeScreen />} />
             <Route path="/lobby/:roomCode" element={<LobbyScreen />} />
+            <Route path="/game/:roomCode" element={<GameScreen />} />
+            <Route path="/leaderboard/:roomCode" element={<LeaderboardScreen />} />
           </Routes>
         </GameProvider>
       </PlayerProvider>

--- a/client/src/screens/LeaderboardScreen.jsx
+++ b/client/src/screens/LeaderboardScreen.jsx
@@ -1,0 +1,156 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { socket } from '../socket';
+import { usePlayer } from '../context/PlayerContext';
+import { useGame } from '../context/GameContext';
+import { Events } from 'shared/events.js';
+import { formatTime } from '../hooks/useCountdown';
+
+const RANK_CLASSES = ['gold', 'silver', 'bronze'];
+const RANK_MEDALS = ['🥇', '🥈', '🥉'];
+
+export default function LeaderboardScreen() {
+  const { roomCode } = useParams();
+  const { player, clearPlayer } = usePlayer();
+  const { gameState, resetGame } = useGame();
+  const navigate = useNavigate();
+
+  // Reconnect if needed
+  useEffect(() => {
+    if (player && !socket.connected) {
+      socket.connect();
+      socket.emit(Events.ROOM_REJOIN, {
+        roomCode: player.roomCode,
+        playerId: player.playerId,
+      });
+    }
+  }, [player]);
+
+  function handlePlayAgain() {
+    navigate(`/lobby/${roomCode}`);
+  }
+
+  function handleHome() {
+    resetGame();
+    clearPlayer();
+    socket.disconnect();
+    navigate('/');
+  }
+
+  if (!gameState) {
+    return (
+      <div className="screen screen-centered">
+        <p className="text-muted">Loading results...</p>
+      </div>
+    );
+  }
+
+  const { leaderboard, roundHistory, settings } = gameState;
+  const isCrazyVariant = settings?.variant === 'crazy_patient';
+
+  return (
+    <div className="screen">
+      <div className="flex-col gap-lg items-center w-full animate-fade-in">
+        <h1 className="title-main" style={{ textAlign: 'center' }}>Game Over!</h1>
+
+        {/* Best Psychiatrist Leaderboard */}
+        <div className="card">
+          <h3 className="mb-md" style={{ color: 'var(--accent-blue)' }}>
+            Best Psychiatrists
+          </h3>
+          {leaderboard.bestPsychiatrist.length === 0 ? (
+            <p className="text-muted">No correct guesses this game!</p>
+          ) : (
+            leaderboard.bestPsychiatrist.map((entry, i) => (
+              <div key={`${entry.playerId}-${entry.round}`} className="leaderboard-entry">
+                <span className={`leaderboard-rank ${RANK_CLASSES[i] || ''}`}>
+                  {RANK_MEDALS[i] || `#${i + 1}`}
+                </span>
+                <div style={{ flex: 1 }}>
+                  <p style={{ fontWeight: 700 }}>{entry.playerName}</p>
+                  <p className="text-muted" style={{ fontSize: '0.8rem' }}>
+                    Round {entry.round} — guessed in {formatTime(entry.time)}
+                  </p>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Crazy Patient Leaderboard */}
+        {isCrazyVariant && (
+          <div className="card">
+            <h3 className="mb-md" style={{ color: 'var(--accent-primary)' }}>
+              Sneakiest Crazies
+            </h3>
+            {leaderboard.crazies.length === 0 ? (
+              <p className="text-muted">Every crazy patient was caught!</p>
+            ) : (
+              leaderboard.crazies.map((entry, i) => (
+                <div key={`${entry.playerId}-${entry.round}`} className="leaderboard-entry">
+                  <span className={`leaderboard-rank ${RANK_CLASSES[i] || ''}`}>
+                    {RANK_MEDALS[i] || `#${i + 1}`}
+                  </span>
+                  <div style={{ flex: 1 }}>
+                    <p style={{ fontWeight: 700 }}>{entry.playerName}</p>
+                    <p className="text-muted" style={{ fontSize: '0.8rem' }}>
+                      Round {entry.round} — hid &quot;{entry.crazySymptom}&quot;
+                    </p>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+
+        {/* Round History */}
+        <div className="card">
+          <h3 className="mb-md">Round History</h3>
+          <div className="flex-col gap-sm">
+            {roundHistory.map(r => (
+              <div
+                key={r.round}
+                style={{
+                  padding: '12px',
+                  background: 'var(--bg-secondary)',
+                  borderRadius: 'var(--border-radius-sm)',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span className="badge badge-green">Round {r.round}</span>
+                  {r.guessedCorrectly ? (
+                    <span style={{ color: 'var(--accent-green)', fontWeight: 700, fontSize: '0.85rem' }}>
+                      ✓ {formatTime(r.guessTime)}
+                    </span>
+                  ) : (
+                    <span style={{ color: 'var(--accent-primary)', fontWeight: 700, fontSize: '0.85rem' }}>
+                      ✗ Not guessed
+                    </span>
+                  )}
+                </div>
+                <p style={{ marginTop: 6, fontWeight: 700 }}>{r.sharedSymptom}</p>
+                <p className="text-muted" style={{ fontSize: '0.8rem', marginTop: 2 }}>
+                  Psychiatrist: {r.psychiatristName}
+                </p>
+                {r.crazyPatientName && (
+                  <p className="text-muted" style={{ fontSize: '0.8rem', marginTop: 2 }}>
+                    Crazy patient: {r.crazyPatientName} (&quot;{r.crazySymptom}&quot;)
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex-col gap-md w-full">
+          <button className="btn btn-primary btn-full" onClick={handlePlayAgain}>
+            Play Again
+          </button>
+          <button className="btn btn-secondary btn-full" onClick={handleHome}>
+            Back to Home
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/screens/LobbyScreen.jsx
+++ b/client/src/screens/LobbyScreen.jsx
@@ -17,6 +17,8 @@ export default function LobbyScreen() {
     symptomSource: 'builtin',
     totalRounds: 5,
   });
+  const [customSymptoms, setCustomSymptoms] = useState([]);
+  const [symptomInput, setSymptomInput] = useState('');
   const [error, setError] = useState('');
 
   const isHost = player?.isHost;
@@ -40,17 +42,27 @@ export default function LobbyScreen() {
     function onError({ message }) {
       setError(message);
     }
+    function onSymptomAdded(symptom) {
+      setCustomSymptoms(prev => [...prev, symptom]);
+    }
+    function onSymptomRemoved({ id }) {
+      setCustomSymptoms(prev => prev.filter(s => s.id !== id));
+    }
 
     socket.on(Events.ROOM_PLAYER_JOINED, onPlayerJoined);
     socket.on(Events.ROOM_PLAYER_LEFT, onPlayerLeft);
     socket.on(Events.LOBBY_SETTINGS_UPDATED, onSettingsUpdated);
     socket.on(Events.ROOM_ERROR, onError);
+    socket.on(Events.LOBBY_SYMPTOM_ADDED, onSymptomAdded);
+    socket.on(Events.LOBBY_SYMPTOM_REMOVED, onSymptomRemoved);
 
     return () => {
       socket.off(Events.ROOM_PLAYER_JOINED, onPlayerJoined);
       socket.off(Events.ROOM_PLAYER_LEFT, onPlayerLeft);
       socket.off(Events.LOBBY_SETTINGS_UPDATED, onSettingsUpdated);
       socket.off(Events.ROOM_ERROR, onError);
+      socket.off(Events.LOBBY_SYMPTOM_ADDED, onSymptomAdded);
+      socket.off(Events.LOBBY_SYMPTOM_REMOVED, onSymptomRemoved);
     };
   }, []);
 
@@ -76,6 +88,9 @@ export default function LobbyScreen() {
     if (gameState && gameState.players) {
       setPlayers(gameState.players);
     }
+    if (gameState && gameState.customSymptoms) {
+      setCustomSymptoms(gameState.customSymptoms);
+    }
   }, [gameState, roomCode, navigate]);
 
   // Initial player list from join/create
@@ -96,7 +111,20 @@ export default function LobbyScreen() {
     socket.emit(Events.LOBBY_UPDATE_SETTINGS, { [key]: value });
   }
 
+  function handleAddSymptom(e) {
+    e.preventDefault();
+    const text = symptomInput.trim();
+    if (!text) return;
+    socket.emit(Events.LOBBY_SUBMIT_SYMPTOM, { text });
+    setSymptomInput('');
+  }
+
+  function handleRemoveSymptom(id) {
+    socket.emit(Events.LOBBY_REMOVE_SYMPTOM, { id });
+  }
+
   const connectedCount = players.filter(p => p.connected).length;
+  const showCustomSymptoms = settings.symptomSource === 'custom' || settings.symptomSource === 'mixed';
 
   return (
     <div className="screen">
@@ -192,6 +220,56 @@ export default function LobbyScreen() {
               {' '} | Rounds: <strong>{settings.totalRounds}</strong>
             </p>
             <p className="text-muted mt-sm">Waiting for host to start...</p>
+          </div>
+        )}
+
+        {/* Custom symptoms */}
+        {showCustomSymptoms && (
+          <div className="card animate-fade-in">
+            <h3 className="mb-md">Custom Symptoms ({customSymptoms.length})</h3>
+            <form onSubmit={handleAddSymptom} className="flex-row gap-sm mb-md">
+              <input
+                className="input"
+                style={{ flex: 1 }}
+                placeholder="Add a symptom..."
+                value={symptomInput}
+                onChange={e => setSymptomInput(e.target.value)}
+                maxLength={80}
+              />
+              <button type="submit" className="btn btn-primary btn-sm" disabled={!symptomInput.trim()}>
+                Add
+              </button>
+            </form>
+            {customSymptoms.length === 0 ? (
+              <p className="text-muted" style={{ fontSize: '0.85rem' }}>No custom symptoms yet.</p>
+            ) : (
+              <div className="flex-col gap-sm">
+                {customSymptoms.map(s => (
+                  <div
+                    key={s.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      padding: '8px 12px',
+                      background: 'var(--bg-secondary)',
+                      borderRadius: 'var(--border-radius-sm)',
+                    }}
+                  >
+                    <span style={{ flex: 1, fontSize: '0.9rem' }}>{s.text}</span>
+                    {isHost && (
+                      <button
+                        className="btn btn-danger btn-sm"
+                        style={{ padding: '4px 10px', fontSize: '0.75rem' }}
+                        onClick={() => handleRemoveSymptom(s.id)}
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

- **Add missing routes** — `/game/:roomCode` and `/leaderboard/:roomCode` were not registered in `App.jsx`, making `GameScreen` unreachable and crashing the app at `END_GAME`
- **Create `LeaderboardScreen`** — shows best psychiatrist leaderboard (sorted by guess time), crazies leaderboard (crazy_patient variant), and per-round history with conditions and outcomes; includes Play Again / Back to Home actions
- **Custom symptoms UI in `LobbyScreen`** — text input to submit symptoms, list with host-only delete, wires `LOBBY_SUBMIT_SYMPTOM`, `LOBBY_SYMPTOM_ADDED`, `LOBBY_REMOVE_SYMPTOM`, `LOBBY_SYMPTOM_REMOVED`; panel only visible when symptom source is `custom` or `mixed`

## Files Affected

- `client/src/App.jsx` — added two routes
- `client/src/screens/LeaderboardScreen.jsx` — new screen
- `client/src/screens/LobbyScreen.jsx` — custom symptoms state, handlers, and UI

## Test plan

- [ ] 4+ browser tabs join a room; host starts game — all tabs navigate to `/game/:roomCode`
- [ ] Play through a full Classic game (role reveal → questioning → guess → results → next round → end game) — all tabs navigate to `/leaderboard/:roomCode` with correct data
- [ ] Play through a Crazy Patient game — crazies leaderboard appears; caught/uncaught entries correct
- [ ] "Play Again" returns to lobby; "Back to Home" clears session and returns to `/`
- [ ] In lobby, select Custom or Mixed symptoms — custom symptom panel appears; can add and (as host) remove symptoms
- [ ] Start game with custom symptoms — selected symptom comes from custom pool
- [ ] All 77 server/shared tests pass: `npm run test`

Closes #3